### PR TITLE
fix: account overflow and sidebar button

### DIFF
--- a/src/features/trip/edit/Tabs/TripTabs.tsx
+++ b/src/features/trip/edit/Tabs/TripTabs.tsx
@@ -30,7 +30,7 @@ function CustomTabPanel({
       hidden={value !== index}
       id={`trip-edit-tabpanel-${index}`}
       aria-labelledby={`trip-edit-tab-${index}`}
-      style={{ height: '90vh' }}
+      style={{ minHeight: '90vh' }}
     >
       {children}
     </div>

--- a/src/features/ui/layout/AccountLayout/AccountLayout.tsx
+++ b/src/features/ui/layout/AccountLayout/AccountLayout.tsx
@@ -85,9 +85,7 @@ export default function AccountLayout() {
       sx={{
         display: "flex",
         bgcolor: "grey.100",
-        minHeight: { md: "100vh" },
-        maxHeight: { xs: "-webkit-fill-available", md: "auto" },
-        height: { xs: "100vh", md: "auto" },
+        minHeight: '100vh',
       }}
     >
       {/* Desktop Drawer */}


### PR DESCRIPTION
Fixed overflow on trip details page
Fixed account sidebard close/open button, to make sure it doesn’t scroll together with the page